### PR TITLE
Pass object to setFooter instead of string

### DIFF
--- a/modules/01-events.js
+++ b/modules/01-events.js
@@ -93,7 +93,7 @@ const Module = new Augur.Module()
       const user = await Module.db.user.fetchUser(newMember).catch(u.noop);
       const embed = u.embed({ author: oldUser })
       .setTitle("User Update")
-      .setFooter(`${user.posts} Posts in ${moment(newMember?.joinedTimestamp).fromNow(true)}`);
+      .setFooter({ text: `${user.posts} Posts in ${moment(newMember?.joinedTimestamp).fromNow(true)}` });
       if (oldUser.tag !== newUser.tag) {
         embed.addField("**Username Update**", `**Old:** ${u.escapeText(oldUser.tag)}\n**New:** ${u.escapeText(newUser.tag)}`);
       }

--- a/modules/01-filter.js
+++ b/modules/01-filter.js
@@ -189,7 +189,7 @@ async function warnCard(msg, filtered, call) {
     }
 
     embed.addField(`Infraction Summary (${infractionSummary.time} Days)`, `Infractions: ${infractionSummary.count}\nPoints: ${infractionSummary.points}`);
-    if (msg.author.bot) embed.setFooter("The user is a bot and the flag likely originated elsewhere. No action will be processed.");
+    if (msg.author.bot) embed.setFooter({ text: "The user is a bot and the flag likely originated elsewhere. No action will be processed." });
 
     let content;
 
@@ -308,7 +308,7 @@ async function processCardAction(interaction) {
       const md = await interaction.client.channels.cache.get(sf.channels.moddiscussion);
       await interaction.reply({ content: `Sending the flag over to ${md}...`, ephemeral: true });
 
-      embed.setFooter(`Linked by ${u.escapeText(mod.displayName)}`);
+      embed.setFooter({ text: `Linked by ${u.escapeText(mod.displayName)}` });
       md.send({ embeds: [embed] }).catch(u.noop);
     } else {
       await interaction.deferUpdate();

--- a/modules/rank.js
+++ b/modules/rank.js
@@ -22,7 +22,7 @@ async function slashRankLeaderboard(interaction) {
     .setThumbnail(interaction.guild.iconURL({ format: "png" }))
     .setURL("https://my.ldsgamers.com/leaderboard")
     .setDescription("Current season chat rankings:\n" + records.join("\n"))
-    .setFooter("Use `/rank track` to join the leaderboard!");
+    .setFooter({ text: "Use `/rank track` to join the leaderboard!" });
 
     await interaction.editReply({ embeds: [embed] });
   } catch (error) { u.errorHandler(error, interaction); }
@@ -56,7 +56,7 @@ async function slashRankView(interaction) {
       const embed = u.embed({ author: member })
       .setTitle("LDSG Season Chat Ranking")
       .setURL("https://my.ldsgamers.com/leaderboard")
-      .setFooter("https://my.ldsgamers.com/leaderboard")
+      .setFooter({ text: "https://my.ldsgamers.com/leaderboard" })
       .addField("Rank", `Season: ${record.rank} / ${members.size}\nLifetime: ${record.lifetime} / ${members.size}`, true)
       .addField("Level", `Current Level: ${level.toLocaleString()}\nNext Level: ${nextLevel} XP`, true)
       .addField("Exp.", `Season: ${record.currentXP.toLocaleString()} XP\nLifetime: ${record.totalXP.toLocaleString()} XP`, true);


### PR DESCRIPTION
Resolves #89

I'm debating how necessary this is; the method signature is marked as deprecated, but are they really going to remove the option to just pass a single string and make us pass an object that _contains_ a single string instead? Shrug. No rush on this PR.