### PR TITLE
Correct username on Minecraft flags

### DIFF
--- a/modules/01-filter.js
+++ b/modules/01-filter.js
@@ -184,10 +184,10 @@ async function warnCard(msg, filtered, call) {
 
     // Minecraft Filter
     if (msg.channel.parentId == sf.channels.minecraftcategory) {
-      embed.addField("User", msg.author.username, true)
+      embed.addField("User", msg.author.username, true);
       msg.client.channels.cache.get(sf.channels.minecraftmods).send({ embeds: [embed] });
     } else {
-      embed.addField("User", msg.author.toString(), true) 
+      embed.addField("User", msg.author.toString(), true);
     }
 
     embed.addField(`Infraction Summary (${infractionSummary.time} Days)`, `Infractions: ${infractionSummary.count}\nPoints: ${infractionSummary.points}`);

--- a/modules/01-filter.js
+++ b/modules/01-filter.js
@@ -180,12 +180,14 @@ async function warnCard(msg, filtered, call) {
     if (filtered) embed.addField("Match", filtered);
 
     embed.addField("Channel", msg.channel?.toString(), true)
-    .addField("User", msg.author.toString(), true)
     .addField("Jump to Post", `[Original Message](${msg.url})`, true);
 
     // Minecraft Filter
     if (msg.channel.parentId == sf.channels.minecraftcategory) {
+      embed.addField("User", msg.author.username, true)
       msg.client.channels.cache.get(sf.channels.minecraftmods).send({ embeds: [embed] });
+    } else {
+      embed.addField("User", msg.author.toString(), true) 
     }
 
     embed.addField(`Infraction Summary (${infractionSummary.time} Days)`, `Infractions: ${infractionSummary.count}\nPoints: ${infractionSummary.points}`);


### PR DESCRIPTION
When it's a Minecraft player, it's a webhook user. This webhook user changes username, and thus the mention changes, every time a new messages is sent in the MC chat.
That means that this flag will show the wrong user if it's a minecraft player that flagged, and another player had talked since.

This PR should fix that.