### PR TITLE
Fix to handle unanticipated Object in API response

### DIFF
--- a/modules/eliteDangerous.js
+++ b/modules/eliteDangerous.js
@@ -60,7 +60,7 @@ async function updateFactions() {
     const old = factions.get(faction.id);
 
     let states = `**Active State:** ${faction.state}`;
-    if (faction.pendingStates.length > 0) states += `\n**Pending State${(faction.pendingStates.length > 1) ? "s" : ""}:** ${faction.pendingStates.join(", ")}`;
+    if (faction.pendingStates.length > 0) states += `\n**Pending State${(faction.pendingStates.length > 1) ? "s" : ""}:** ${faction.pendingStates.map(state => state.state).join(", ")}`;
 
     if (!old) {
       embed.addField(`${faction.name} (${(100 * faction.influence).toFixed(2)}%)`, states, true);


### PR DESCRIPTION
We just received a pending state for the first time. The `.pendingStates` property is formatted as:
```js
{
 pendingStates: [ { state: 'State Name', trend: 0 } ]
}
```