### PR TITLE
Fix Unknown User on flagCreate

### DIFF
--- a/utils/modCommon.js
+++ b/utils/modCommon.js
@@ -158,7 +158,7 @@ const modCommon = {
       client.channels.cache.get(sf.channels.minecraftmods).send({ embeds: [embed] });
       if (msg.webhookId) return;
     } else if (msg.webhookId) {
-      if (msg.webhookId) embed.addField("User", msg.author.toString());
+      if (msg.webhookId) embed.addField("User", msg.author.username);
     } else {
       embed.addField("User", member.toString(), true);
     }

--- a/utils/modCommon.js
+++ b/utils/modCommon.js
@@ -156,7 +156,6 @@ const modCommon = {
       if (msg.webhookId) embed.addField("User", msg.author.username ?? (await msg.channel.fetchWebhooks()).get(msg.webhookId)?.name ?? "Unknown User");
       else embed.addField("User", (member.displayName ?? (await member.fetch()).displayName), true);
       client.channels.cache.get(sf.channels.minecraftmods).send({ embeds: [embed] });
-      if (msg.webhookId) return;
     } else if (msg.webhookId) {
       if (msg.webhookId) embed.addField("User", msg.author.username);
     } else {

--- a/utils/modCommon.js
+++ b/utils/modCommon.js
@@ -153,8 +153,12 @@ const modCommon = {
     }
 
     if (msg && msg.channel.parentId == sf.channels.minecraftcategory) {
-      embed.addField("User", (member.displayName ?? (await member.fetch()).displayName), true);
+      if (msg.webhookId) embed.addField("User", msg.author.username ?? (await msg.channel.fetchWebhooks()).get(msg.webhookId)?.name ?? "Unknown User");
+      else embed.addField("User", (member.displayName ?? (await member.fetch()).displayName), true);
       client.channels.cache.get(sf.channels.minecraftmods).send({ embeds: [embed] });
+      if (msg.webhookId) return;
+    } else if (msg.webhookId) {
+      if (msg.webhookId) embed.addField("User", msg.author.toString());
     } else {
       embed.addField("User", member.toString(), true);
     }


### PR DESCRIPTION
Resolves #184 
The member object doesn't exist on a webhook, so when language pops up in one it will try fetching a member that doesn't exist. I've added a check for webhooks that uses the author instead of member and a backup of fetching the webhook